### PR TITLE
[BUGFIX] Remove inclusion of none-excisting interface

### DIFF
--- a/classes/Hooks/class.tx_varnish_hooks_clearcachemenu.php
+++ b/classes/Hooks/class.tx_varnish_hooks_clearcachemenu.php
@@ -32,8 +32,6 @@
  */
 
 
-require_once(PATH_typo3 . 'interfaces/interface.backend_cacheActionsHook.php');
-
 class tx_varnish_hooks_clearcachemenu implements backend_cacheActionsHook {
 
 


### PR DESCRIPTION
As inclusion is done through the autoloader since 4.3 this inclusion can be removed
