### PR TITLE
Add Sitename and TYPO3 Install-Id to support multiple TYPO3 installations

### DIFF
--- a/classes/Hooks/class.tx_varnish_hooks_tslib_fe.php
+++ b/classes/Hooks/class.tx_varnish_hooks_tslib_fe.php
@@ -45,6 +45,8 @@ class tx_varnish_hooks_tslib_fe {
 		// Send Page pid which is used to issue BAN Command against
 		if(t3lib_div::getIndpEnv('TYPO3_REV_PROXY') == 1) {
 			header('TYPO3-Pid: ' . $parent->id);
+			header('TYPO3-Sitename: ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']);
+			header('TYPO3-Install-Id: ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['T3instID']);
 		}
 	}
 

--- a/classes/class.tx_varnish_controller.php
+++ b/classes/class.tx_varnish_controller.php
@@ -78,7 +78,11 @@ class tx_varnish_controller {
 		// if cacheCmd is a single Page, issue BAN Command on this pid
 		// all other Commands ("page", "all") led to a BAN of the whole Cache
 		$cacheCmd = intval($cacheCmd);
-		$command = $cacheCmd > 0 ? 'Varnish-Ban-TYPO3-Pid: ' . $cacheCmd : 'Varnish-Ban-All: 1';
+		$command = array(
+			$cacheCmd > 0 ? 'Varnish-Ban-TYPO3-Pid: ' . $cacheCmd : 'Varnish-Ban-All: 1',
+			'Varnish-Ban-TYPO3-Sitename: ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'],
+			'Varnish-Ban-TYPO3-Install-Id: ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['T3instID'],
+		);
 
 		// issue command on every Varnish Server
 		/** @var $varnishHttp tx_varnish_http */

--- a/res/default.vcl
+++ b/res/default.vcl
@@ -55,7 +55,11 @@ sub vcl_recv {
 			error 200 "Banned all";
 		}
 
-		if(req.http.Varnish-Ban-TYPO3-Pid) {
+		if(req.http.Varnish-Ban-TYPO3-Pid && req.http.Varnish-Ban-TYPO3-Sitename && req.http.Varnish-Ban-TYPO3-Install-Id) {
+			ban("obj.http.TYPO3-Pid == " + req.http.Varnish-Ban-TYPO3-Pid + " && obj.http.TYPO3-Sitename == " + req.http.Varnish-Ban-TYPO3-Sitename + " && obj.http.TYPO3-Install-Id == " + req.http.Varnish-Ban-TYPO3-Install-Id);
+			error 202 "Banned TYPO3 pid " + req.http.Varnish-Ban-TYPO3-Pid + " on site " + req.http.Varnish-Ban-TYPO3-Sitename;
+		}
+		else if(req.http.Varnish-Ban-TYPO3-Pid) {
 			ban("obj.http.TYPO3-Pid == " + req.http.Varnish-Ban-TYPO3-Pid);
 			error 200 "Banned TYPO3 pid " + req.http.Varnish-Ban-TYPO3-Pid;
 		}
@@ -151,6 +155,8 @@ sub vcl_deliver {
 
 	# smart Ban related
 	unset resp.http.TYPO3-Pid;
+	unset resp.http.TYPO3-Sitename;
+	unset resp.http.TYPO3-Install-Id;
 
 	return (deliver);
 }


### PR DESCRIPTION
This patch adds 2 more headers to the page output and extends BAN requests to support multiple TYPO3 installations on the same server.
