### PR TITLE
[BUGFIX] Use lowercase for generalutility class name

### DIFF
--- a/classes/Hooks/class.tx_varnish_hooks_tslib_fe.php
+++ b/classes/Hooks/class.tx_varnish_hooks_tslib_fe.php
@@ -46,7 +46,7 @@ class tx_varnish_hooks_tslib_fe {
 		// Send Page pid which is used to issue BAN Command against
 		if(t3lib_div::getIndpEnv('TYPO3_REV_PROXY') == 1 || $extConf['alwaysSendTypo3Headers'] == 1) {
 			header('TYPO3-Pid: ' . $parent->id);
-			header('TYPO3-Sitename: ' . tx_varnish_GeneralUtility::getSitename());
+			header('TYPO3-Sitename: ' . tx_varnish_generalutility::getSitename());
 		}
 	}
 

--- a/classes/Utilities/class.tx_varnish_generalutility.php
+++ b/classes/Utilities/class.tx_varnish_generalutility.php
@@ -36,7 +36,7 @@
  * @package	TYPO3
  * @subpackage	tx_varnish
  */
-class tx_varnish_GeneralUtility {
+class tx_varnish_generalutility {
 
 	static $extConf;
 

--- a/classes/class.tx_varnish_controller.php
+++ b/classes/class.tx_varnish_controller.php
@@ -73,14 +73,14 @@ class tx_varnish_controller {
 
 	public function clearCache($cacheCmd) {
 
-		tx_varnish_GeneralUtility::devLog('clearCache', array('cacheCmd' => $cacheCmd));
+		tx_varnish_generalutility::devLog('clearCache', array('cacheCmd' => $cacheCmd));
 
 		// if cacheCmd is a single Page, issue BAN Command on this pid
 		// all other Commands ("page", "all") led to a BAN of the whole Cache
 		$cacheCmd = intval($cacheCmd);
 		$command = array(
 			$cacheCmd > 0 ? 'Varnish-Ban-TYPO3-Pid: ' . $cacheCmd : 'Varnish-Ban-All: 1',
-			'Varnish-Ban-TYPO3-Sitename: ' . tx_varnish_GeneralUtility::getSitename()
+			'Varnish-Ban-TYPO3-Sitename: ' . tx_varnish_generalutility::getSitename()
 		);
 
 		// issue command on every Varnish Server

--- a/classes/class.tx_varnish_http.php
+++ b/classes/class.tx_varnish_http.php
@@ -103,8 +103,6 @@ class tx_varnish_http {
 			CURLOPT_RETURNTRANSFER  => 1,
 		);
 
-		tx_varnish_GeneralUtility::devLog(__FUNCTION__, $curlOptions);
-
 		curl_setopt_array($curlHandle, $curlOptions);
 		curl_multi_add_handle(self::$curlQueue, $curlHandle);
 
@@ -132,7 +130,7 @@ class tx_varnish_http {
 
 	protected static function runQueue() {
 
-		tx_varnish_GeneralUtility::devLog(__FUNCTION__);
+		tx_varnish_generalutility::devLog(__FUNCTION__);
 
 		$running = null;
 		do {


### PR DESCRIPTION
Since the extension supports TYPO3 4.5+ and the extension structure
    and class names don't support implicit class autoloading, the classes
    are registered in ext_autoload.php. In ext_autoload.php, the class
    names need to be in lowercase (this limitation was removed in TYPO3
    6.0). As a consequence, "tx_varnish_GeneralUtility" is named
    "tx_varnish_generalutility" in the ext_autoload.php file. This is
    why in some cases TYPO3 fails to call the class, leading to a fatal
    error.

```
To remain backwards compatibility, but the class and all references to
it should be written in lowercase.
```
