### PR TITLE
[FEATURE] add function that clears custom cache key

### DIFF
--- a/Classes/Controller/VarnishController.php
+++ b/Classes/Controller/VarnishController.php
@@ -101,4 +101,28 @@ class VarnishController
             $varnishHttp::addCommand($method, $currentHost, $command);
         }
     }
+
+    /**
+     * ClearCache by setting a specific Ban header.
+     *
+     * @param $key
+     * @param $value
+     */
+    public function clearCustomCache($key, $value)
+    {
+        // Log debug infos
+        VarnishGeneralUtility::devLog('clearCache', array (
+            'cacheCmdKey' => $key, 'cacheCmdValue' => $value
+        ));
+
+        $command = 'Varnish-Ban-' . $key . ': ' . $value;
+        $method = VarnishGeneralUtility::getProperty('banRequestMethod') ?: 'BAN';
+
+        // issue command on every Varnish Server
+        /** @var $varnishHttp VarnishHttpUtility */
+        $varnishHttp = GeneralUtility::makeInstance(VarnishHttpUtility::class);
+        foreach ($this->instanceHostnames as $currentHost) {
+            $varnishHttp::addCommand($method, $currentHost, $command);
+        }
+    }
 }


### PR DESCRIPTION
Hi!

I needed to clear the varnish cache when certain domain objects changed, regardless of any pid.
So I wrote a function which lets me specify a custom key to ban.

Of course the varnish config has to be changed accordingly. In my case that meant adding these lines:
```
if(req.http.Varnish-Ban-TYPO3-LodgeUid) {
  ban("obj.http.TYPO3-LodgeUid == " + req.http.Varnish-Ban-TYPO3-LodgeUid);
  return(synth(200, "Banned TYPO3 Lodge uid " + req.http.Varnish-Ban-TYPO3-LodgeUid));
}
```
in `vcl_recv` and
```
unset resp.http.TYPO3-LodgeUid;
```
in `vcl_deliver`. `LodgeUid` can be anything.

Since I duplicated some functionality, this should probably be refactored before merging, but I wanted to propose the changes as I originally made them.

Kind regards,
yeldiR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/snowflakeops/typo3-varnish/45)
<!-- Reviewable:end -->
